### PR TITLE
install k9s as user

### DIFF
--- a/Dockerfiles/Python/Dockerfile
+++ b/Dockerfiles/Python/Dockerfile
@@ -38,7 +38,9 @@ WORKDIR /scripts
 RUN ./install-python.sh
 RUN ./install-dapr-cli.sh
 RUN ./install-k3d-prerequisites.sh
+USER 4000
 RUN ./install-k3d-tooling.sh
+USER root
 
 WORKDIR /requirements
 
@@ -46,5 +48,3 @@ RUN pip3 install -r requirements-dev.txt
 RUN pip3 install -r requirements-links.txt
 RUN pip3 install -r requirements.txt
 RUN pip3 install -r requirements-test.txt
-
-RUN apt-get autoremove -y


### PR DESCRIPTION
Commands inside a Dockerfile are executed as 'root' by default. This leeds to the problem that K9S gets installed in /root and is therefore inaccessible for other users. 

That's why we are installing K9S now as a user. UID 4000 is used as standard for the vscode user in devcontainers. 

Fixes #5 