### PR TITLE
replace reference category

### DIFF
--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -104,6 +104,8 @@ jobs:
         run: |
           syft -o spdx-json=SBOM/python.spdx.json -o cyclonedx-json=SBOM/python.cyclonedx.json ghcr.io/${{ github.repository }}/python:${{ needs.build-image.outputs.tag }}
           syft -o spdx-json=SBOM/cpp.spdx.json -o cyclonedx-json=SBOM/cpp.cyclonedx.json ghcr.io/${{ github.repository }}/cpp:${{ needs.build-image.outputs.tag }}
+          # fix for different SPDX versions
+          sed -i -e 's/PACKAGE-MANAGER/PACKAGE_MANAGER/g' SBOM/python.spdx.json SBOM/cpp.spdx.json
 
       - name: Upload SBOM as artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
The OCAAS tools use an older version of SPDX than the tools we used to generate the documents. This fixes an mismatch between the versions.

The old version used PACKAGE_MANAGER as reference category, whereas the newer versions use PACKAGE-MANAGER. This PR simply replaces them.