### PR TITLE
Update container upload handling

### DIFF
--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Linters
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -54,22 +54,27 @@ jobs:
         with:
           version: v0.9.0
 
-      - name: Get image tag
-        id: get-tag
-        shell: bash
-        run: |
-          TAGS=${{ github.sha }}
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            TAGS="${TAGS},latest"
-          fi
-          echo "tag=${{ github.sha }}" >> $GITHUB_OUTPUT
-          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
-
       - id: github-repository-name-case-adjusted
         name: Prepare repository name in lower case for docker upload.
         uses: ASzc/change-string-case-action@v6
         with:
           string: ${{ github.repository }}
+
+      - name: Decide on upload strategy
+        id: get-tag
+        shell: bash
+        run: |
+          if [[ ("${{ github.event_name }}" == "pull_request") ]] ; then
+            TAGS=${{ github.sha }}
+            IMAGE_NAME=ttl.sh/eclipse-velocitas/${{ steps.github-repository-name-case-adjusted.outputs.lowercase }}/${{ matrix.image }}
+            echo "push_ttl=true" >> $GITHUB_OUTPUT
+          else
+            TAGS="latest"
+            IMAGE_NAME=ghcr.io/${{ steps.github-repository-name-case-adjusted.outputs.lowercase }}/${{ matrix.image }}
+            echo "push_ttl=false" >> $GITHUB_OUTPUT
+          fi
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "image_name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -82,12 +87,18 @@ jobs:
         id: image_build
         uses: devcontainers/ci@v0.3
         with:
-          imageName: ghcr.io/${{ steps.github-repository-name-case-adjusted.outputs.lowercase }}/${{ matrix.image }}
+          imageName: ${{ steps.get-tag.outputs.image_name }}
           imageTag: ${{ steps.get-tag.outputs.tags }}
           push: always
           platform: linux/amd64,linux/arm64
           noCache: true
           subFolder: ./Dockerfiles/${{ matrix.image }}/
+
+      - name: Posting ttl.sh message
+        if: steps.get-tag.outputs.push_ttl == 'true'
+        uses: eclipse-kuksa/kuksa-actions/post-container-location@4
+        with:
+          image: ${{ steps.get-tag.outputs.image_name }}:${{ steps.get-tag.outputs.tags }}
 
   generate-sbom:
     name: Generate SBOM

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -45,19 +45,27 @@ jobs:
           generate-dash: true
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v3.13.0
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Run dash
         shell: bash
-        continue-on-error: true
         env:
           GITLAB_TOKEN:
         run: |
           wget -O dash.jar "https://repo.eclipse.org/content/repositories/dash-licenses/org/eclipse/dash/org.eclipse.dash.licenses/1.0.2/org.eclipse.dash.licenses-1.0.2.jar"
-          java -jar dash.jar -project automotive.velocitas -review -token ${{ secrets.GITLAB_API_TOKEN }} -summary DEPENDENCIES clearlydefined.input 2> output.log
+          if [[ -n "${{ secrets.GITLAB_API_TOKEN }}" ]]; then
+            echo -e "Dash token available. Will create tickets when required. \n " >> $GITHUB_STEP_SUMMARY
+            java -jar dash.jar -project automotive.velocitas -review -token ${{ secrets.GITLAB_API_TOKEN }} -summary DEPENDENCIES clearlydefined.input > dash.out 2>&1 || true
+          else
+            echo -e "Dash token not available. Will perform checking only. \n " >> $GITHUB_STEP_SUMMARY
+            java -jar dash.jar -project automotive.velocitas -summary DEPENDENCIES clearlydefined.input > dash.out 2>&1 || true
+          fi
+          echo -e "Dash output: \n\`\`\` " >> $GITHUB_STEP_SUMMARY
+          cat dash.out >> $GITHUB_STEP_SUMMARY
+          echo -e "\n\`\`\`"
 
       - name: Upload dash input/output as artifacts
         uses: actions/upload-artifact@v4

--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -4,13 +4,14 @@
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|
 |actions/checkout|v4|MIT License|
-|actions/setup-java|v3.13.0|MIT License|
+|actions/setup-java|v4|MIT License|
 |actions/upload-artifact|v4|MIT License|
 |ASzc/change-string-case-action|v6|ISC License|
 |devcontainers/ci|v0.3|MIT License|
 |docker/login-action|v3|Apache License 2.0|
 |docker/setup-buildx-action|v3|Apache License 2.0|
 |docker/setup-qemu-action|v3|Apache License 2.0|
+|eclipse-kuksa/kuksa-actions|4|Apache License 2.0|
 |EndBug/add-and-commit|v9|MIT License|
 |fountainhead/action-wait-for-check|v1.2.0|MIT License|
-|pre-commit/action|v3.0.0|MIT License|
+|pre-commit/action|v3.0.1|MIT License|


### PR DESCRIPTION
Fixes #70 

This PR addresses two "problems":

- As of today every PR (and merge) results in a new image at https://github.com/eclipse-velocitas/devcontainer-base-images/pkgs/container/devcontainer-base-images%2Fbase (and cpp/python) that will stay there practically forever, as we do not have any easy mechanism to clean them out
- PRs from other forks will not pass CI as they cannot upload images to eclipse-velocitas ghcr (see #70) 

This PR uses reuses some ideas from eclipse-kuksa and https://github.com/eclipse-kuksa/kuksa-actions/blob/main/.github/workflows/check_ghcr_push.yml and https://github.com/eclipse-kuksa/kuksa-databroker, to use ttl.sh for temporary images and never publish sha-tagged versions at ghcr.io

- To see who it would work for push, look at https://github.com/erikbosch/devcontainer-base-images
- To see how it would work for PRs, look at build actions for this PR.

ttl.sh images are short lived and address can be found in build results

![image](https://github.com/eclipse-velocitas/devcontainer-base-images/assets/30996601/80abc7fd-e5ba-4fe9-b31a-80b2e4e696f9)

It also incorporates the improved license check printout from https://github.com/eclipse-velocitas/devenv-github-workflows/blob/35b40c5503b08db0722bfa5fcf83d0a6a20c8bb1/src/common/workflows/check-licenses.yml, but adapted to check if there is a token and otherwise just use a check




## Differences compared to Kuksa

Lets say they use different philosophy:

- Kuksa workflows/actions only push to ghcr if using the "vanilla kuksa repositories", forks will only push to ttl.sh, also on merge/push
- Kuksa use the tag "latest" for the latest released version. Velocitas for the latest merged version. (Kuksa use "main" for latest merged)




