### PR TITLE
Fix build from fork

### DIFF
--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Linters
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -64,6 +64,11 @@ jobs:
           fi
           echo "tag=${{ github.sha }}" >> $GITHUB_OUTPUT
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          if [[ ("${{ github.event_name }}" == "pull_request") ]] ; then
+            echo "ci_push=never" >> $GITHUB_OUTPUT
+          else
+            echo "ci_push=always" >> $GITHUB_OUTPUT
+          fi
 
       - id: github-repository-name-case-adjusted
         name: Prepare repository name in lower case for docker upload.
@@ -84,7 +89,7 @@ jobs:
         with:
           imageName: ghcr.io/${{ steps.github-repository-name-case-adjusted.outputs.lowercase }}/${{ matrix.image }}
           imageTag: ${{ steps.get-tag.outputs.tags }}
-          push: always
+          push: ${{ steps.get-tag.outputs.ci_push }}
           platform: linux/amd64,linux/arm64
           noCache: true
           subFolder: ./Dockerfiles/${{ matrix.image }}/

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -45,7 +45,7 @@ jobs:
           generate-dash: true
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v3.13.0
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -57,7 +57,16 @@ jobs:
           GITLAB_TOKEN:
         run: |
           wget -O dash.jar "https://repo.eclipse.org/content/repositories/dash-licenses/org/eclipse/dash/org.eclipse.dash.licenses/1.0.2/org.eclipse.dash.licenses-1.0.2.jar"
-          java -jar dash.jar -project automotive.velocitas -review -token ${{ secrets.GITLAB_API_TOKEN }} -summary DEPENDENCIES clearlydefined.input 2> output.log
+          if [[ -n "${{ secrets.GITLAB_API_TOKEN }}" ]]; then
+            echo -e "Dash token available. Will create tickets when required. \n " >> $GITHUB_STEP_SUMMARY
+            java -jar dash.jar -project automotive.velocitas -review -token ${{ secrets.GITLAB_API_TOKEN }} -summary DEPENDENCIES clearlydefined.input > dash.out 2>&1 || true
+          else
+            echo -e "Dash token not available. Will perform checking only. \n " >> $GITHUB_STEP_SUMMARY
+            java -jar dash.jar -project automotive.velocitas -summary DEPENDENCIES clearlydefined.input > dash.out 2>&1 || true
+          fi
+          echo -e "Dash output: \n\`\`\` " >> $GITHUB_STEP_SUMMARY
+          cat dash.out >> $GITHUB_STEP_SUMMARY
+          echo -e "\n\`\`\`"
 
       - name: Upload dash input/output as artifacts
         uses: actions/upload-artifact@v4

--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -4,7 +4,7 @@
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|
 |actions/checkout|v4|MIT License|
-|actions/setup-java|v3.13.0|MIT License|
+|actions/setup-java|v4|MIT License|
 |actions/upload-artifact|v4|MIT License|
 |ASzc/change-string-case-action|v6|ISC License|
 |devcontainers/ci|v0.3|MIT License|
@@ -13,4 +13,4 @@
 |docker/setup-qemu-action|v3|Apache License 2.0|
 |EndBug/add-and-commit|v9|MIT License|
 |fountainhead/action-wait-for-check|v1.2.0|MIT License|
-|pre-commit/action|v3.0.0|MIT License|
+|pre-commit/action|v3.0.1|MIT License|


### PR DESCRIPTION
We do not need builds from Pull Requests to be uploaded to ghcr. By removing builds from PRs we solve the problem that PRs originating from a fork cannot upload images to ghcr.

Fixes #70 
Replaces #69 

Fixes also some CI warnings and improves dash printout

Tested that pusihing to main still creates ghcr image at https://github.com/erikbosch/devcontainer-base-images/pkgs/container/devcontainer-base-images%2Fbase