### PR TITLE
Update urllib3 (indirectly - used by Conan) to fix vulnerabilities

### DIFF
--- a/Dockerfiles/cpp/.devcontainer/devcontainer.json
+++ b/Dockerfiles/cpp/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
         "dockerfile": "Dockerfile",
         "context": "../../..",
         "args": {
-            "SDK_TAG": "v0.7.0"
+            "SDK_TAG": "v0.7.1"
         }
     },
     "features": {


### PR DESCRIPTION
Fixes:
- urllib3 streaming API improperly handles highly compressed data
- urllib3 allows an unbounded number of links in the decompression chain
- urllib3 redirects are not disabled when retries are disabled on PoolManager instantiation
- urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects